### PR TITLE
Fix login via root using authorized key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ADD sshd_config /etc/ssh/sshd_config
 
 RUN mkdir /root/.ssh && \
     chmod 700 /root/.ssh
+RUN passwd -u root
 
 EXPOSE 22
 

--- a/sshd_config
+++ b/sshd_config
@@ -1,1 +1,3 @@
 StreamLocalBindUnlink yes
+PermitRootLogin yes
+PasswordAuthentication no


### PR DESCRIPTION
When built from current Dockerfile, root login via ssh is not permitted despite the authorized key. This commit fixes that.